### PR TITLE
fix(generate): special chars in refs handling

### DIFF
--- a/src/codegen/generate.ts
+++ b/src/codegen/generate.ts
@@ -245,11 +245,8 @@ export default class ApiGenerator {
     let ref = this.refs[$ref];
     if (!ref) {
       const schema = this.resolve<OpenAPIV3.SchemaObject>(obj);
-      const removeChars = ['\/', '.', '-', ':']
       const name = this.getUniqueAlias(
-        _.upperFirst(
-          (schema.title || this.getRefBasename($ref)).split(new RegExp(`[${removeChars.join('|')}]`)).map((s, i) => `${i === 0 ? '' : '__'}${s.charAt(0).toUpperCase()}${s.slice(1)}`).join('')
-        )
+        _.upperFirst(_.camelCase(schema.title || this.getRefBasename($ref)))
       );
 
       ref = this.refs[$ref] = factory.createTypeReferenceNode(name, undefined);


### PR DESCRIPTION
## Fixes
https://github.com/rtk-incubator/rtk-query-codegen/issues/15

Already fixed by @fgnass here https://github.com/cellular/oazapfts/commit/25d67ba6519be8ad41661a15a412d5167b847c82